### PR TITLE
Port to Python 3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = zc.zservertracelog
+
+[report]
+exclude_lines =
+    pragma: nocover
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 *.egg-info/
 .tox/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
     - pip install coveralls coverage zope.testrunner
     - pip install -e .[test]
 script:
-    - bin/test -pvc
     - coverage run -m zope.testrunner --test-path=src -pvc
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: python
-sudo: false
+dist: xenial
 python:
-    - 2.6
     - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - 3.7
+    - pypy2.7-6.0.0
+    - pypy3.5-6.0.0
 install:
-    - python bootstrap.py
-    - bin/buildout
+    - pip install coveralls coverage zope.testrunner
+    - pip install -e .[test]
 script:
     - bin/test -pvc
+    - coverage run -m zope.testrunner --test-path=src -pvc
+after_success:
+    - coveralls
 notifications:
     email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,14 @@
 Changes
 =======
 
-1.4.1 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Limit number precision in HTML reports to 3 decimal digits.
+
+- Drop Python 2.6 support.
+
+- Add Python 3.4 through 3.7 support.
 
 
 1.4.0 (2015-05-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 2.0.0 (unreleased)
 ------------------
 
+- Fix logic bug in seconds_difference() that could introduce error up to nearly
+  a whole second for any particular event.
+
 - Limit number precision in HTML reports to 3 decimal digits.
 
 - Drop Python 2.6 support.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include *.rst
 include buildout.cfg
 include tox.ini
 recursive-include src *.log
-recursive-include src *.txt
+recursive-include src *.rst
 recursive-include src *.zcml

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*rnames):
 
 setup(
     name='zc.zservertracelog',
-    version='1.4.1.dev0',
+    version='2.0.0.dev0',
     url='https://github.com/zopefoundation/zc.zservertracelog',
     author='Zope Corporation and Contributors',
     author_email='zope3-dev@zope.org',
@@ -34,23 +34,32 @@ setup(
     ),
     license='ZPL 2.1',
     keywords='zope3',
+    classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+    ],
     packages=find_packages('src'),
     namespace_packages=['zc'],
     package_dir={'': 'src'},
     install_requires=[
         'setuptools',
+        'six',
         'zope.app.appsetup',
         'zope.app.server',
         'zope.app.wsgi',
+        'zope.component',
+        'zope.interface',
+        'zope.publisher',
         'zope.server',
     ],
     extras_require=dict(
         test=[
-            # Our test suite uses zope.testing.doctest.INTERPRET_FOOTNOTES
-            # That feature is gone from zope.testing 4.0.0 with the entire
-            # zope.testing.doctest fork of the stdlib's doctest.  The proper
-            # way forward would be to switch to Manuel.
-            'zope.testing < 4.0.0',
+            'manuel',
         ],
     ),
     include_package_data=True,

--- a/src/zc/zservertracelog/README.rst
+++ b/src/zc/zservertracelog/README.rst
@@ -57,7 +57,7 @@ Let's also define a convenience function for processing requests.
 
 Process a simple request.
 
-    >>> req1 = """\
+    >>> req1 = b"""\
     ... GET /test-req1 HTTP/1.1
     ... Host: www.example.com
     ...
@@ -150,7 +150,7 @@ Log Messages Containing Line Breaks
 Messages to the tracelog that contain newline characters will not split a log
 entry into multiple lines.
 
-    >>> req2 = """\
+    >>> req2 = b"""\
     ... GET /test-req2/%0Aohnoes/ HTTP/1.1
     ... Host: www.example.com/linebreak
     ...
@@ -169,7 +169,7 @@ Request Query Strings
 
 The tracelog preserves request query strings.
 
-    >>> req3 = """\
+    >>> req3 = b"""\
     ... GET /test-req3/?creature=unicorn HTTP/1.1
     ... Host: www.example.com/query-string
     ...

--- a/src/zc/zservertracelog/fseek.py
+++ b/src/zc/zservertracelog/fseek.py
@@ -1,9 +1,13 @@
-import StringIO
-import string
 import unittest
 
+from six.moves import cStringIO as StringIO
 
-def fseek(f, size, search, getkey=string.strip):
+
+def strip(s):
+    return s.strip()
+
+
+def fseek(f, size, search, getkey=strip):
     # Check first line
     key = getkey(f.readline())
     if key >= search:
@@ -12,15 +16,15 @@ def fseek(f, size, search, getkey=string.strip):
 
     seen = 0
     position = 0
-    seek = chunk = size / 2
+    seek = chunk = size // 2
     while chunk > 0:
         f.seek(seek)
-        line = f.readline() # maybe incomplete
+        line = f.readline()  # maybe incomplete
         position = f.tell()
-        line = f.readline() # complete
+        line = f.readline()  # complete
         key = getkey(line)
 
-        chunk /= 2
+        chunk //= 2
 
         if key >= search:
             seek -= chunk
@@ -37,7 +41,7 @@ def fseek(f, size, search, getkey=string.strip):
 
 def _get_btree_args(*lines):
     content = '\n'.join(lines)
-    f = StringIO.StringIO(content)
+    f = StringIO(content)
     size = len(content)
     return (f, size)
 
@@ -60,16 +64,20 @@ class FSeekTest(unittest.TestCase):
         p = fseek(f, size, '0')
         self.assertEqual(p, 0)
 
-        f.seek(0) ; p = fseek(f, size, '1')
+        f.seek(0)
+        p = fseek(f, size, '1')
         self.assertEqual(p, 2)
 
-        f.seek(0) ; p = fseek(f, size, '2')
+        f.seek(0)
+        p = fseek(f, size, '2')
         self.assertEqual(p, 4)
 
-        f.seek(0) ; p = fseek(f, size, '3')
+        f.seek(0)
+        p = fseek(f, size, '3')
         self.assertEqual(p, 6)
 
-        f.seek(0) ; p = fseek(f, size, '4')
+        f.seek(0)
+        p = fseek(f, size, '4')
         self.assertEqual(p, 8)
 
     def test_2(self):
@@ -88,10 +96,12 @@ class FSeekTest(unittest.TestCase):
         p = fseek(f, size, '0')
         self.assertEqual(p, 0)
 
-        f.seek(0) ; p = fseek(f, size, '1')
+        f.seek(0)
+        p = fseek(f, size, '1')
         self.assertEqual(p, 6)
 
-        f.seek(0) ; p = fseek(f, size, '2')
+        f.seek(0)
+        p = fseek(f, size, '2')
         self.assertEqual(p, 12)
 
     def test_3(self):
@@ -106,18 +116,18 @@ class FSeekTest(unittest.TestCase):
         p = fseek(f, size, '0')
         self.assertEqual(p, 0)
 
-        f.seek(0) ; p = fseek(f, size, '1', _get_colon_key)
+        f.seek(0)
+        p = fseek(f, size, '1', _get_colon_key)
         self.assertEqual(p, 16)
 
-        f.seek(0) ; p = fseek(f, size, '2', _get_colon_key)
+        f.seek(0)
+        p = fseek(f, size, '2', _get_colon_key)
         self.assertEqual(p, 26)
 
-        f.seek(0) ; p = fseek(f, size, '3', _get_colon_key)
+        f.seek(0)
+        p = fseek(f, size, '3', _get_colon_key)
         self.assertEqual(p, 67)
 
-        f.seek(0) ; p = fseek(f, size, '4', _get_colon_key)
+        f.seek(0)
+        p = fseek(f, size, '4', _get_colon_key)
         self.assertEqual(p, 76)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/src/zc/zservertracelog/tests.py
+++ b/src/zc/zservertracelog/tests.py
@@ -16,6 +16,7 @@
 """
 __docformat__ = "reStructuredText"
 
+import datetime
 import doctest
 import os
 import re
@@ -26,7 +27,9 @@ import manuel.footnote
 import manuel.testing
 import zope.testing.renormalizing
 
-from zc.zservertracelog.fseek import FSeekTest
+from zc.zservertracelog.fseek import FSeekTest  # noqa
+from zc.zservertracelog.tracereport import seconds_difference
+
 
 here = os.path.dirname(os.path.abspath(__file__))
 
@@ -59,6 +62,14 @@ class FauxApplication(object):
         return app(environ, start_response)
 
 
+class TestHelpers(unittest.TestCase):
+
+    def test_seconds_difference(self):
+        dt1 = datetime.datetime(2019, 2, 23, 14, 5, 54, 451)
+        dt2 = dt1 + datetime.timedelta(minutes=15, seconds=3, microseconds=42)
+        self.assertEqual(seconds_difference(dt2, dt1), 15 * 60 + 3 + 0.000042)
+
+
 def setUp(test):
     test.globs['FauxApplication'] = FauxApplication
 
@@ -79,5 +90,5 @@ def test_suite():
             'tracereport.rst',
             checker=checker,
             setUp=analysis_setUp),
-        unittest.makeSuite(FSeekTest),
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
     ])

--- a/src/zc/zservertracelog/tracereport.py
+++ b/src/zc/zservertracelog/tracereport.py
@@ -137,8 +137,7 @@ class Times(object):
 
 def seconds_difference(dt1, dt2):
     delta = dt1 - dt2
-    micros = float('0.' + str(delta.microseconds))    # XXX: this is Wrong!
-    return delta.seconds + micros
+    return delta.seconds + delta.microseconds * 1e-6
 
 
 def parse_line(line):

--- a/src/zc/zservertracelog/tracereport.rst
+++ b/src/zc/zservertracelog/tracereport.rst
@@ -8,6 +8,8 @@ report.
     >>> import os
     >>> os.environ['COLUMNS'] = '70'
     >>> import zc.zservertracelog.tracereport
+    >>> import sys
+    >>> sys.argv[0] = 'tracereport'
 
 The '--help' option displays the following usage information:
 
@@ -15,8 +17,8 @@ The '--help' option displays the following usage information:
     ...     zc.zservertracelog.tracereport.main(['--help'])
     ... except SystemExit:
     ...     pass
-    ... # doctest: +REPORT_NDIFF
-    Usage: test [options] trace_log_file
+    ... # doctest: +REPORT_NDIFF, +NORMALIZE_WHITESPACE
+    Usage: tracereport [options] trace_log_file
     <BLANKLINE>
     Output trace log data showing:
     <BLANKLINE>
@@ -127,123 +129,123 @@ This can also be displayed as HTML.
     <tr><th>Impact</th><th>count</th><th>min</th>
     <th>median</th><th>mean</th><th>max</th><th>hangs</th></tr>
     <tr>
-    <td><a name="u37">62.41844</a></td><td>1</td><td>62.41844</td><td>62.41844</td><td>62.41844</td><td>62.41844</td><td>0</td>
+    <td><a name="u37">62.4</a></td><td>1</td><td>62.418</td><td>62.418</td><td>62.418</td><td>62.418</td><td>0</td>
     <td>/constellations/andromeda.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u53">61.502412</a></td><td>1</td><td>61.502412</td><td>61.502412</td><td>61.502412</td><td>61.502412</td><td>0</td>
+    <td><a name="u53">61.5</a></td><td>1</td><td>61.502</td><td>61.502</td><td>61.502</td><td>61.502</td><td>0</td>
     <td>/stars/alpha-centauri.html</td>
     </tr>
     <tr>
-    <td><a name="u34">60.6803</a></td><td>2</td><td>0.3372</td><td>30.34015</td><td>30.34015</td><td>60.3431</td><td>0</td>
+    <td><a name="u34">60.7</a></td><td>2</td><td>0.337</td><td>30.340</td><td>30.340</td><td>60.343</td><td>0</td>
     <td>/space-travel/plans/supplies.txt</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u44">60.267171</a></td><td>2</td><td>0.132899</td><td>30.1335855</td><td>30.1335855</td><td>60.134272</td><td>0</td>
+    <td><a name="u44">60.3</a></td><td>2</td><td>0.133</td><td>30.134</td><td>30.134</td><td>60.134</td><td>0</td>
     <td>/favicon.png</td>
     </tr>
     <tr>
-    <td><a name="u48">9.693661</a></td><td>1</td><td>9.693661</td><td>9.693661</td><td>9.693661</td><td>9.693661</td><td>0</td>
+    <td><a name="u48">9.7</a></td><td>1</td><td>9.694</td><td>9.694</td><td>9.694</td><td>9.694</td><td>0</td>
     <td>/planets/saturn.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u51">8.29953</a></td><td>1</td><td>8.29953</td><td>8.29953</td><td>8.29953</td><td>8.29953</td><td>0</td>
+    <td><a name="u51">8.3</a></td><td>1</td><td>8.300</td><td>8.300</td><td>8.300</td><td>8.300</td><td>0</td>
     <td>/moons/io.html</td>
     </tr>
     <tr>
-    <td><a name="u55">7.339574</a></td><td>1</td><td>7.339574</td><td>7.339574</td><td>7.339574</td><td>7.339574</td><td>0</td>
+    <td><a name="u55">7.3</a></td><td>1</td><td>7.340</td><td>7.340</td><td>7.340</td><td>7.340</td><td>0</td>
     <td>/planets/jupiter.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u56">1.0394</a></td><td>3</td><td>0.3092</td><td>0.3526</td><td>0.346466666667</td><td>0.3776</td><td>0</td>
+    <td><a name="u56">1.0</a></td><td>3</td><td>0.309</td><td>0.353</td><td>0.346</td><td>0.378</td><td>0</td>
     <td>/space-travel/plans/signals.html</td>
     </tr>
     <tr>
-    <td><a name="u60">0.879732</a></td><td>1</td><td>0.879732</td><td>0.879732</td><td>0.879732</td><td>0.879732</td><td>0</td>
+    <td><a name="u60">0.9</a></td><td>1</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0</td>
     <td>/stories/aliens-posing-as-humans.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u36">0.7755</a></td><td>2</td><td>0.3523</td><td>0.38775</td><td>0.38775</td><td>0.4232</td><td>0</td>
+    <td><a name="u36">0.8</a></td><td>2</td><td>0.352</td><td>0.388</td><td>0.388</td><td>0.423</td><td>0</td>
     <td>/space-travel/plans/launchpad.html</td>
     </tr>
     <tr>
-    <td><a name="u62">0.729</a></td><td>1</td><td>0.3645</td><td>0.3645</td><td>0.3645</td><td>0.3645</td><td>1</td>
+    <td><a name="u62">0.7</a></td><td>1</td><td>0.364</td><td>0.364</td><td>0.364</td><td>0.364</td><td>1</td>
     <td>/space-travel/plans/orbit.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u38">0.7221</a></td><td>2</td><td>0.3385</td><td>0.36105</td><td>0.36105</td><td>0.3836</td><td>0</td>
+    <td><a name="u38">0.7</a></td><td>2</td><td>0.339</td><td>0.361</td><td>0.361</td><td>0.384</td><td>0</td>
     <td>/space-travel/plans/space-logs.txt</td>
     </tr>
     <tr>
-    <td><a name="u35">0.6988</a></td><td>2</td><td>0.3474</td><td>0.3494</td><td>0.3494</td><td>0.3514</td><td>0</td>
+    <td><a name="u35">0.7</a></td><td>2</td><td>0.347</td><td>0.349</td><td>0.349</td><td>0.351</td><td>0</td>
     <td>/space-travel/plans/moon-base.jpg</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u33">0.63826</a></td><td>1</td><td>0.63826</td><td>0.63826</td><td>0.63826</td><td>0.63826</td><td>0</td>
+    <td><a name="u33">0.6</a></td><td>1</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0</td>
     <td>/columns/t-jansen</td>
     </tr>
     <tr>
-    <td><a name="u45">0.49124</a></td><td>3</td><td>0.1529</td><td>0.16141</td><td>0.163746666667</td><td>0.17693</td><td>0</td>
+    <td><a name="u45">0.5</a></td><td>3</td><td>0.153</td><td>0.161</td><td>0.164</td><td>0.177</td><td>0</td>
     <td>/space-travelers/famous/kirk.jpg</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u46">0.3967</a></td><td>1</td><td>0.3967</td><td>0.3967</td><td>0.3967</td><td>0.3967</td><td>0</td>
+    <td><a name="u46">0.4</a></td><td>1</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0</td>
     <td>/space-travel/plans/moon-buggy.jpg</td>
     </tr>
     <tr>
-    <td><a name="u49">0.3794</a></td><td>1</td><td>0.3794</td><td>0.3794</td><td>0.3794</td><td>0.3794</td><td>0</td>
+    <td><a name="u49">0.4</a></td><td>1</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0</td>
     <td>/space-travel/plans/space-diary.txt</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u41">0.374609</a></td><td>2</td><td>0.184486</td><td>0.1873045</td><td>0.1873045</td><td>0.190123</td><td>0</td>
+    <td><a name="u41">0.4</a></td><td>2</td><td>0.184</td><td>0.187</td><td>0.187</td><td>0.190</td><td>0</td>
     <td>/faqs/how-to-recognize-lazer-fire.html</td>
     </tr>
     <tr>
-    <td><a name="u58">0.3542</a></td><td>1</td><td>0.3542</td><td>0.3542</td><td>0.3542</td><td>0.3542</td><td>0</td>
+    <td><a name="u58">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
     <td>/js/photo.js</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u63">0.354</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
+    <td><a name="u63">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
     <td>/space-travel/plans/visor.jpg</td>
     </tr>
     <tr>
-    <td><a name="u52">0.3526</a></td><td>1</td><td>0.3526</td><td>0.3526</td><td>0.3526</td><td>0.3526</td><td>0</td>
+    <td><a name="u52">0.4</a></td><td>1</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0</td>
     <td>/space-travel/plans/lunar-cycles.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u54">0.350755</a></td><td>1</td><td>0.350755</td><td>0.350755</td><td>0.350755</td><td>0.350755</td><td>0</td>
+    <td><a name="u54">0.4</a></td><td>1</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0</td>
     <td>/faqs/how-to-charge-lazers.html</td>
     </tr>
     <tr>
-    <td><a name="u40">0.3325</a></td><td>1</td><td>0.3325</td><td>0.3325</td><td>0.3325</td><td>0.3325</td><td>0</td>
+    <td><a name="u40">0.3</a></td><td>1</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0</td>
     <td>/space-travel/plans/cryostasis.txt</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u47">0.3211</a></td><td>1</td><td>0.3211</td><td>0.3211</td><td>0.3211</td><td>0.3211</td><td>0</td>
+    <td><a name="u47">0.3</a></td><td>1</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0</td>
     <td>/space-travel/plans/space-suit.jpg</td>
     </tr>
     <tr>
-    <td><a name="u50">0.31994</a></td><td>1</td><td>0.31994</td><td>0.31994</td><td>0.31994</td><td>0.31994</td><td>0</td>
+    <td><a name="u50">0.3</a></td><td>1</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0</td>
     <td>/space-travel/ships/tardis.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u39">0.252708</a></td><td>1</td><td>0.252708</td><td>0.252708</td><td>0.252708</td><td>0.252708</td><td>0</td>
+    <td><a name="u39">0.3</a></td><td>1</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0</td>
     <td>/approve-photo</td>
     </tr>
     <tr>
-    <td><a name="u57">0.181654</a></td><td>1</td><td>0.181654</td><td>0.181654</td><td>0.181654</td><td>0.181654</td><td>0</td>
+    <td><a name="u57">0.2</a></td><td>1</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0</td>
     <td>/ufo-sightings/report</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u59">0.15727</a></td><td>1</td><td>0.15727</td><td>0.15727</td><td>0.15727</td><td>0.15727</td><td>0</td>
+    <td><a name="u59">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
     <td>/space-travelers/famous/spock.jpg</td>
     </tr>
     <tr>
-    <td><a name="u43">0.15669</a></td><td>1</td><td>0.15669</td><td>0.15669</td><td>0.15669</td><td>0.15669</td><td>0</td>
+    <td><a name="u43">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
     <td>/login</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u61">0.137797</a></td><td>1</td><td>0.137797</td><td>0.137797</td><td>0.137797</td><td>0.137797</td><td>0</td>
+    <td><a name="u61">0.1</a></td><td>1</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0</td>
     <td>/space-travel/ships/soyuz.html</td>
     </tr>
     <tr>
@@ -506,123 +508,123 @@ Again, this report is also available in HTML form.
     <tr><th>Impact</th><th>count</th><th>min</th>
     <th>median</th><th>mean</th><th>max</th><th>hangs</th></tr>
     <tr>
-    <td><a name="u99">62.41844</a></td><td>1</td><td>62.41844</td><td>62.41844</td><td>62.41844</td><td>62.41844</td><td>0</td>
+    <td><a name="u99">62.4</a></td><td>1</td><td>62.418</td><td>62.418</td><td>62.418</td><td>62.418</td><td>0</td>
     <td>/constellations/andromeda.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u115">61.502412</a></td><td>1</td><td>61.502412</td><td>61.502412</td><td>61.502412</td><td>61.502412</td><td>0</td>
+    <td><a name="u115">61.5</a></td><td>1</td><td>61.502</td><td>61.502</td><td>61.502</td><td>61.502</td><td>0</td>
     <td>/stars/alpha-centauri.html</td>
     </tr>
     <tr>
-    <td><a name="u96">60.6803</a></td><td>2</td><td>0.3372</td><td>30.34015</td><td>30.34015</td><td>60.3431</td><td>0</td>
+    <td><a name="u96">60.7</a></td><td>2</td><td>0.337</td><td>30.340</td><td>30.340</td><td>60.343</td><td>0</td>
     <td>/space-travel/plans/supplies.txt</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u106">60.267171</a></td><td>2</td><td>0.132899</td><td>30.1335855</td><td>30.1335855</td><td>60.134272</td><td>0</td>
+    <td><a name="u106">60.3</a></td><td>2</td><td>0.133</td><td>30.134</td><td>30.134</td><td>60.134</td><td>0</td>
     <td>/favicon.png</td>
     </tr>
     <tr>
-    <td><a name="u110">9.693661</a></td><td>1</td><td>9.693661</td><td>9.693661</td><td>9.693661</td><td>9.693661</td><td>0</td>
+    <td><a name="u110">9.7</a></td><td>1</td><td>9.694</td><td>9.694</td><td>9.694</td><td>9.694</td><td>0</td>
     <td>/planets/saturn.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u113">8.29953</a></td><td>1</td><td>8.29953</td><td>8.29953</td><td>8.29953</td><td>8.29953</td><td>0</td>
+    <td><a name="u113">8.3</a></td><td>1</td><td>8.300</td><td>8.300</td><td>8.300</td><td>8.300</td><td>0</td>
     <td>/moons/io.html</td>
     </tr>
     <tr>
-    <td><a name="u117">7.339574</a></td><td>1</td><td>7.339574</td><td>7.339574</td><td>7.339574</td><td>7.339574</td><td>0</td>
+    <td><a name="u117">7.3</a></td><td>1</td><td>7.340</td><td>7.340</td><td>7.340</td><td>7.340</td><td>0</td>
     <td>/planets/jupiter.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u118">1.0394</a></td><td>3</td><td>0.3092</td><td>0.3526</td><td>0.346466666667</td><td>0.3776</td><td>0</td>
+    <td><a name="u118">1.0</a></td><td>3</td><td>0.309</td><td>0.353</td><td>0.346</td><td>0.378</td><td>0</td>
     <td>/space-travel/plans/signals.html</td>
     </tr>
     <tr>
-    <td><a name="u122">0.879732</a></td><td>1</td><td>0.879732</td><td>0.879732</td><td>0.879732</td><td>0.879732</td><td>0</td>
+    <td><a name="u122">0.9</a></td><td>1</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0</td>
     <td>/stories/aliens-posing-as-humans.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u98">0.7755</a></td><td>2</td><td>0.3523</td><td>0.38775</td><td>0.38775</td><td>0.4232</td><td>0</td>
+    <td><a name="u98">0.8</a></td><td>2</td><td>0.352</td><td>0.388</td><td>0.388</td><td>0.423</td><td>0</td>
     <td>/space-travel/plans/launchpad.html</td>
     </tr>
     <tr>
-    <td><a name="u124">0.729</a></td><td>1</td><td>0.3645</td><td>0.3645</td><td>0.3645</td><td>0.3645</td><td>1</td>
+    <td><a name="u124">0.7</a></td><td>1</td><td>0.364</td><td>0.364</td><td>0.364</td><td>0.364</td><td>1</td>
     <td>/space-travel/plans/orbit.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u100">0.7221</a></td><td>2</td><td>0.3385</td><td>0.36105</td><td>0.36105</td><td>0.3836</td><td>0</td>
+    <td><a name="u100">0.7</a></td><td>2</td><td>0.339</td><td>0.361</td><td>0.361</td><td>0.384</td><td>0</td>
     <td>/space-travel/plans/space-logs.txt</td>
     </tr>
     <tr>
-    <td><a name="u97">0.6988</a></td><td>2</td><td>0.3474</td><td>0.3494</td><td>0.3494</td><td>0.3514</td><td>0</td>
+    <td><a name="u97">0.7</a></td><td>2</td><td>0.347</td><td>0.349</td><td>0.349</td><td>0.351</td><td>0</td>
     <td>/space-travel/plans/moon-base.jpg</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u95">0.63826</a></td><td>1</td><td>0.63826</td><td>0.63826</td><td>0.63826</td><td>0.63826</td><td>0</td>
+    <td><a name="u95">0.6</a></td><td>1</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0</td>
     <td>/columns/t-jansen</td>
     </tr>
     <tr>
-    <td><a name="u107">0.49124</a></td><td>3</td><td>0.1529</td><td>0.16141</td><td>0.163746666667</td><td>0.17693</td><td>0</td>
+    <td><a name="u107">0.5</a></td><td>3</td><td>0.153</td><td>0.161</td><td>0.164</td><td>0.177</td><td>0</td>
     <td>/space-travelers/famous/kirk.jpg</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u108">0.3967</a></td><td>1</td><td>0.3967</td><td>0.3967</td><td>0.3967</td><td>0.3967</td><td>0</td>
+    <td><a name="u108">0.4</a></td><td>1</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0</td>
     <td>/space-travel/plans/moon-buggy.jpg</td>
     </tr>
     <tr>
-    <td><a name="u111">0.3794</a></td><td>1</td><td>0.3794</td><td>0.3794</td><td>0.3794</td><td>0.3794</td><td>0</td>
+    <td><a name="u111">0.4</a></td><td>1</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0</td>
     <td>/space-travel/plans/space-diary.txt</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u103">0.374609</a></td><td>2</td><td>0.184486</td><td>0.1873045</td><td>0.1873045</td><td>0.190123</td><td>0</td>
+    <td><a name="u103">0.4</a></td><td>2</td><td>0.184</td><td>0.187</td><td>0.187</td><td>0.190</td><td>0</td>
     <td>/faqs/how-to-recognize-lazer-fire.html</td>
     </tr>
     <tr>
-    <td><a name="u120">0.3542</a></td><td>1</td><td>0.3542</td><td>0.3542</td><td>0.3542</td><td>0.3542</td><td>0</td>
+    <td><a name="u120">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
     <td>/js/photo.js</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u125">0.354</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
+    <td><a name="u125">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
     <td>/space-travel/plans/visor.jpg</td>
     </tr>
     <tr>
-    <td><a name="u114">0.3526</a></td><td>1</td><td>0.3526</td><td>0.3526</td><td>0.3526</td><td>0.3526</td><td>0</td>
+    <td><a name="u114">0.4</a></td><td>1</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0</td>
     <td>/space-travel/plans/lunar-cycles.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u116">0.350755</a></td><td>1</td><td>0.350755</td><td>0.350755</td><td>0.350755</td><td>0.350755</td><td>0</td>
+    <td><a name="u116">0.4</a></td><td>1</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0</td>
     <td>/faqs/how-to-charge-lazers.html</td>
     </tr>
     <tr>
-    <td><a name="u102">0.3325</a></td><td>1</td><td>0.3325</td><td>0.3325</td><td>0.3325</td><td>0.3325</td><td>0</td>
+    <td><a name="u102">0.3</a></td><td>1</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0</td>
     <td>/space-travel/plans/cryostasis.txt</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u109">0.3211</a></td><td>1</td><td>0.3211</td><td>0.3211</td><td>0.3211</td><td>0.3211</td><td>0</td>
+    <td><a name="u109">0.3</a></td><td>1</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0</td>
     <td>/space-travel/plans/space-suit.jpg</td>
     </tr>
     <tr>
-    <td><a name="u112">0.31994</a></td><td>1</td><td>0.31994</td><td>0.31994</td><td>0.31994</td><td>0.31994</td><td>0</td>
+    <td><a name="u112">0.3</a></td><td>1</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0</td>
     <td>/space-travel/ships/tardis.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u101">0.252708</a></td><td>1</td><td>0.252708</td><td>0.252708</td><td>0.252708</td><td>0.252708</td><td>0</td>
+    <td><a name="u101">0.3</a></td><td>1</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0</td>
     <td>/approve-photo</td>
     </tr>
     <tr>
-    <td><a name="u119">0.181654</a></td><td>1</td><td>0.181654</td><td>0.181654</td><td>0.181654</td><td>0.181654</td><td>0</td>
+    <td><a name="u119">0.2</a></td><td>1</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0</td>
     <td>/ufo-sightings/report</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u121">0.15727</a></td><td>1</td><td>0.15727</td><td>0.15727</td><td>0.15727</td><td>0.15727</td><td>0</td>
+    <td><a name="u121">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
     <td>/space-travelers/famous/spock.jpg</td>
     </tr>
     <tr>
-    <td><a name="u105">0.15669</a></td><td>1</td><td>0.15669</td><td>0.15669</td><td>0.15669</td><td>0.15669</td><td>0</td>
+    <td><a name="u105">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
     <td>/login</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u123">0.137797</a></td><td>1</td><td>0.137797</td><td>0.137797</td><td>0.137797</td><td>0.137797</td><td>0</td>
+    <td><a name="u123">0.1</a></td><td>1</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0</td>
     <td>/space-travel/ships/soyuz.html</td>
     </tr>
     <tr>

--- a/src/zc/zservertracelog/tracereport.rst
+++ b/src/zc/zservertracelog/tracereport.rst
@@ -88,34 +88,34 @@ Here, we display the summarized report for a sample trace log.
     ========= ===== ====== ====== ====== ====== =====
          62.4     1  62.42  62.42  62.42  62.42     0 /constellations/andromeda.html
          61.5     1  61.50  61.50  61.50  61.50     0 /stars/alpha-centauri.html
-         60.7     2   0.34  30.34  30.34  60.34     0 /space-travel/plans/supplies.txt
          60.3     2   0.13  30.13  30.13  60.13     0 /favicon.png
+         60.0     2   0.00  30.00  30.00  60.00     0 /space-travel/plans/supplies.txt
           9.7     1   9.69   9.69   9.69   9.69     0 /planets/saturn.html
           8.3     1   8.30   8.30   8.30   8.30     0 /moons/io.html
           7.3     1   7.34   7.34   7.34   7.34     0 /planets/jupiter.html
-          1.0     3   0.31   0.35   0.35   0.38     0 /space-travel/plans/signals.html
           0.9     1   0.88   0.88   0.88   0.88     0 /stories/aliens-posing-as-humans.html
-          0.8     2   0.35   0.39   0.39   0.42     0 /space-travel/plans/launchpad.html
-          0.7     1   0.36   0.36   0.36   0.36     1 /space-travel/plans/orbit.html
-          0.7     2   0.34   0.36   0.36   0.38     0 /space-travel/plans/space-logs.txt
-          0.7     2   0.35   0.35   0.35   0.35     0 /space-travel/plans/moon-base.jpg
           0.6     1   0.64   0.64   0.64   0.64     0 /columns/t-jansen
-          0.5     3   0.15   0.16   0.16   0.18     0 /space-travelers/famous/kirk.jpg
-          0.4     1   0.40   0.40   0.40   0.40     0 /space-travel/plans/moon-buggy.jpg
-          0.4     1   0.38   0.38   0.38   0.38     0 /space-travel/plans/space-diary.txt
           0.4     2   0.18   0.19   0.19   0.19     0 /faqs/how-to-recognize-lazer-fire.html
-          0.4     1   0.35   0.35   0.35   0.35     0 /js/photo.js
-          0.4     1   0.35   0.35   0.35   0.35     0 /space-travel/plans/visor.jpg
-          0.4     1   0.35   0.35   0.35   0.35     0 /space-travel/plans/lunar-cycles.html
           0.4     1   0.35   0.35   0.35   0.35     0 /faqs/how-to-charge-lazers.html
-          0.3     1   0.33   0.33   0.33   0.33     0 /space-travel/plans/cryostasis.txt
-          0.3     1   0.32   0.32   0.32   0.32     0 /space-travel/plans/space-suit.jpg
           0.3     1   0.32   0.32   0.32   0.32     0 /space-travel/ships/tardis.html
           0.3     1   0.25   0.25   0.25   0.25     0 /approve-photo
           0.2     1   0.18   0.18   0.18   0.18     0 /ufo-sightings/report
-          0.2     1   0.16   0.16   0.16   0.16     0 /space-travelers/famous/spock.jpg
-          0.2     1   0.16   0.16   0.16   0.16     0 /login
           0.1     1   0.14   0.14   0.14   0.14     0 /space-travel/ships/soyuz.html
+          0.0     3   0.02   0.02   0.02   0.02     0 /space-travelers/famous/kirk.jpg
+          0.0     1   0.02   0.02   0.02   0.02     0 /space-travelers/famous/spock.jpg
+          0.0     1   0.02   0.02   0.02   0.02     0 /login
+          0.0     3   0.00   0.00   0.00   0.00     0 /space-travel/plans/signals.html
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/launchpad.html
+          0.0     1   0.00   0.00   0.00   0.00     1 /space-travel/plans/orbit.html
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-logs.txt
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/moon-base.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/moon-buggy.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-diary.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /js/photo.js
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/visor.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/lunar-cycles.html
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/cryostasis.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-suit.jpg
                   0                                 1 /submit-photo
 
 This can also be displayed as HTML.
@@ -137,12 +137,12 @@ This can also be displayed as HTML.
     <td>/stars/alpha-centauri.html</td>
     </tr>
     <tr>
-    <td><a name="u34">60.7</a></td><td>2</td><td>0.337</td><td>30.340</td><td>30.340</td><td>60.343</td><td>0</td>
-    <td>/space-travel/plans/supplies.txt</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u44">60.3</a></td><td>2</td><td>0.133</td><td>30.134</td><td>30.134</td><td>60.134</td><td>0</td>
     <td>/favicon.png</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u34">60.0</a></td><td>2</td><td>0.003</td><td>30.003</td><td>30.003</td><td>60.003</td><td>0</td>
+    <td>/space-travel/plans/supplies.txt</td>
     </tr>
     <tr>
     <td><a name="u48">9.7</a></td><td>1</td><td>9.694</td><td>9.694</td><td>9.694</td><td>9.694</td><td>0</td>
@@ -157,96 +157,96 @@ This can also be displayed as HTML.
     <td>/planets/jupiter.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u56">1.0</a></td><td>3</td><td>0.309</td><td>0.353</td><td>0.346</td><td>0.378</td><td>0</td>
-    <td>/space-travel/plans/signals.html</td>
-    </tr>
-    <tr>
     <td><a name="u60">0.9</a></td><td>1</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0</td>
     <td>/stories/aliens-posing-as-humans.html</td>
     </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u36">0.8</a></td><td>2</td><td>0.352</td><td>0.388</td><td>0.388</td><td>0.423</td><td>0</td>
-    <td>/space-travel/plans/launchpad.html</td>
-    </tr>
     <tr>
-    <td><a name="u62">0.7</a></td><td>1</td><td>0.364</td><td>0.364</td><td>0.364</td><td>0.364</td><td>1</td>
-    <td>/space-travel/plans/orbit.html</td>
-    </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u38">0.7</a></td><td>2</td><td>0.339</td><td>0.361</td><td>0.361</td><td>0.384</td><td>0</td>
-    <td>/space-travel/plans/space-logs.txt</td>
-    </tr>
-    <tr>
-    <td><a name="u35">0.7</a></td><td>2</td><td>0.347</td><td>0.349</td><td>0.349</td><td>0.351</td><td>0</td>
-    <td>/space-travel/plans/moon-base.jpg</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u33">0.6</a></td><td>1</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0</td>
     <td>/columns/t-jansen</td>
-    </tr>
-    <tr>
-    <td><a name="u45">0.5</a></td><td>3</td><td>0.153</td><td>0.161</td><td>0.164</td><td>0.177</td><td>0</td>
-    <td>/space-travelers/famous/kirk.jpg</td>
-    </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u46">0.4</a></td><td>1</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0</td>
-    <td>/space-travel/plans/moon-buggy.jpg</td>
-    </tr>
-    <tr>
-    <td><a name="u49">0.4</a></td><td>1</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0</td>
-    <td>/space-travel/plans/space-diary.txt</td>
     </tr>
     <tr style="background: lightgrey;">
     <td><a name="u41">0.4</a></td><td>2</td><td>0.184</td><td>0.187</td><td>0.187</td><td>0.190</td><td>0</td>
     <td>/faqs/how-to-recognize-lazer-fire.html</td>
     </tr>
     <tr>
-    <td><a name="u58">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
-    <td>/js/photo.js</td>
-    </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u63">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
-    <td>/space-travel/plans/visor.jpg</td>
-    </tr>
-    <tr>
-    <td><a name="u52">0.4</a></td><td>1</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0</td>
-    <td>/space-travel/plans/lunar-cycles.html</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u54">0.4</a></td><td>1</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0</td>
     <td>/faqs/how-to-charge-lazers.html</td>
     </tr>
-    <tr>
-    <td><a name="u40">0.3</a></td><td>1</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0</td>
-    <td>/space-travel/plans/cryostasis.txt</td>
-    </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u47">0.3</a></td><td>1</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0</td>
-    <td>/space-travel/plans/space-suit.jpg</td>
-    </tr>
-    <tr>
     <td><a name="u50">0.3</a></td><td>1</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0</td>
     <td>/space-travel/ships/tardis.html</td>
     </tr>
-    <tr style="background: lightgrey;">
+    <tr>
     <td><a name="u39">0.3</a></td><td>1</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0</td>
     <td>/approve-photo</td>
     </tr>
-    <tr>
+    <tr style="background: lightgrey;">
     <td><a name="u57">0.2</a></td><td>1</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0</td>
     <td>/ufo-sightings/report</td>
     </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u59">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
-    <td>/space-travelers/famous/spock.jpg</td>
-    </tr>
     <tr>
-    <td><a name="u43">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
-    <td>/login</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u61">0.1</a></td><td>1</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0</td>
     <td>/space-travel/ships/soyuz.html</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u45">0.0</a></td><td>3</td><td>0.015</td><td>0.016</td><td>0.016</td><td>0.018</td><td>0</td>
+    <td>/space-travelers/famous/kirk.jpg</td>
+    </tr>
+    <tr>
+    <td><a name="u59">0.0</a></td><td>1</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0</td>
+    <td>/space-travelers/famous/spock.jpg</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u43">0.0</a></td><td>1</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0</td>
+    <td>/login</td>
+    </tr>
+    <tr>
+    <td><a name="u56">0.0</a></td><td>3</td><td>0.003</td><td>0.004</td><td>0.003</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/signals.html</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u36">0.0</a></td><td>2</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/launchpad.html</td>
+    </tr>
+    <tr>
+    <td><a name="u62">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>1</td>
+    <td>/space-travel/plans/orbit.html</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u38">0.0</a></td><td>2</td><td>0.003</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/space-logs.txt</td>
+    </tr>
+    <tr>
+    <td><a name="u35">0.0</a></td><td>2</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/moon-base.jpg</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u46">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/moon-buggy.jpg</td>
+    </tr>
+    <tr>
+    <td><a name="u49">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/space-diary.txt</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u58">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/js/photo.js</td>
+    </tr>
+    <tr>
+    <td><a name="u63">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/visor.jpg</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u52">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/lunar-cycles.html</td>
+    </tr>
+    <tr>
+    <td><a name="u40">0.0</a></td><td>1</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0</td>
+    <td>/space-travel/plans/cryostasis.txt</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u47">0.0</a></td><td>1</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0</td>
+    <td>/space-travel/plans/space-suit.jpg</td>
     </tr>
     <tr>
     <td><a name="u42">&nbsp;</a></td><td>0</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>1</td>
@@ -263,19 +263,19 @@ The full report shows the request activity per minute.
               minute   req input  wait   app output
     ================ ===== ===== ===== ===== ======
     2009-07-30 15:47     1 I=  0 W=  0 A=  1 O=   0 N=   1       0.64       0.64
-    60.4106 /space-travel/plans/supplies.txt
-    2009-07-30 15:48     2 I=  0 W=  1 A=  1 O=   0 N=   3      20.43      20.35
+    60.004106 /space-travel/plans/supplies.txt
+    2009-07-30 15:48     2 I=  0 W=  1 A=  1 O=   0 N=   3      20.00      20.00
     60.791825 /constellations/andromeda.html
-    2009-07-30 15:49     0 I=  0 W=  0 A=  0 O=   0 N=   4      31.81      15.85
-    2009-07-30 15:50     2 I=  0 W=  0 A=  2 O=   0 N=   2       0.34       0.17
+    2009-07-30 15:49     0 I=  0 W=  0 A=  0 O=   0 N=   4      31.69      15.67
+    2009-07-30 15:50     2 I=  0 W=  0 A=  2 O=   0 N=   2       0.34       0.10
     60.62335 /submit-photo
     60.209388 /favicon.png
-    2009-07-30 15:51     3 I=  0 W=  1 A=  1 O=   1 N=   5      12.31      12.25
+    2009-07-30 15:51     3 I=  0 W=  1 A=  1 O=   1 N=   5      12.08      12.07
     121.301024 /submit-photo
-    2009-07-30 15:52     3 I=  0 W=  1 A=  2 O=   0 N=   8      20.65       2.52
+    2009-07-30 15:52     3 I=  0 W=  1 A=  2 O=   0 N=   8      20.45       2.29
     200.494494 /submit-photo
-    68.9801 /stars/alpha-centauri.html
-    2009-07-30 15:53     3 I=  0 W=  2 A=  1 O=   0 N=  11      14.53       6.53
+    68.09801 /stars/alpha-centauri.html
+    2009-07-30 15:53     3 I=  0 W=  2 A=  1 O=   0 N=  11      14.39       6.39
     270.622261 /submit-photo
     Left over:
     271.214443 /submit-photo
@@ -286,34 +286,34 @@ The full report shows the request activity per minute.
     ========= ===== ====== ====== ====== ====== =====
          62.4     1  62.42  62.42  62.42  62.42     0 /constellations/andromeda.html
          61.5     1  61.50  61.50  61.50  61.50     0 /stars/alpha-centauri.html
-         60.7     2   0.34  30.34  30.34  60.34     0 /space-travel/plans/supplies.txt
          60.3     2   0.13  30.13  30.13  60.13     0 /favicon.png
+         60.0     2   0.00  30.00  30.00  60.00     0 /space-travel/plans/supplies.txt
           9.7     1   9.69   9.69   9.69   9.69     0 /planets/saturn.html
           8.3     1   8.30   8.30   8.30   8.30     0 /moons/io.html
           7.3     1   7.34   7.34   7.34   7.34     0 /planets/jupiter.html
-          1.0     3   0.31   0.35   0.35   0.38     0 /space-travel/plans/signals.html
           0.9     1   0.88   0.88   0.88   0.88     0 /stories/aliens-posing-as-humans.html
-          0.8     2   0.35   0.39   0.39   0.42     0 /space-travel/plans/launchpad.html
-          0.7     1   0.36   0.36   0.36   0.36     1 /space-travel/plans/orbit.html
-          0.7     2   0.34   0.36   0.36   0.38     0 /space-travel/plans/space-logs.txt
-          0.7     2   0.35   0.35   0.35   0.35     0 /space-travel/plans/moon-base.jpg
           0.6     1   0.64   0.64   0.64   0.64     0 /columns/t-jansen
-          0.5     3   0.15   0.16   0.16   0.18     0 /space-travelers/famous/kirk.jpg
-          0.4     1   0.40   0.40   0.40   0.40     0 /space-travel/plans/moon-buggy.jpg
-          0.4     1   0.38   0.38   0.38   0.38     0 /space-travel/plans/space-diary.txt
           0.4     2   0.18   0.19   0.19   0.19     0 /faqs/how-to-recognize-lazer-fire.html
-          0.4     1   0.35   0.35   0.35   0.35     0 /js/photo.js
-          0.4     1   0.35   0.35   0.35   0.35     0 /space-travel/plans/visor.jpg
-          0.4     1   0.35   0.35   0.35   0.35     0 /space-travel/plans/lunar-cycles.html
           0.4     1   0.35   0.35   0.35   0.35     0 /faqs/how-to-charge-lazers.html
-          0.3     1   0.33   0.33   0.33   0.33     0 /space-travel/plans/cryostasis.txt
-          0.3     1   0.32   0.32   0.32   0.32     0 /space-travel/plans/space-suit.jpg
           0.3     1   0.32   0.32   0.32   0.32     0 /space-travel/ships/tardis.html
           0.3     1   0.25   0.25   0.25   0.25     0 /approve-photo
           0.2     1   0.18   0.18   0.18   0.18     0 /ufo-sightings/report
-          0.2     1   0.16   0.16   0.16   0.16     0 /space-travelers/famous/spock.jpg
-          0.2     1   0.16   0.16   0.16   0.16     0 /login
           0.1     1   0.14   0.14   0.14   0.14     0 /space-travel/ships/soyuz.html
+          0.0     3   0.02   0.02   0.02   0.02     0 /space-travelers/famous/kirk.jpg
+          0.0     1   0.02   0.02   0.02   0.02     0 /space-travelers/famous/spock.jpg
+          0.0     1   0.02   0.02   0.02   0.02     0 /login
+          0.0     3   0.00   0.00   0.00   0.00     0 /space-travel/plans/signals.html
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/launchpad.html
+          0.0     1   0.00   0.00   0.00   0.00     1 /space-travel/plans/orbit.html
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-logs.txt
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/moon-base.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/moon-buggy.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-diary.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /js/photo.js
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/visor.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/lunar-cycles.html
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/cryostasis.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-suit.jpg
                   0                                 1 /submit-photo
 
 Again, this report is also available in HTML form.
@@ -358,7 +358,7 @@ Again, this report is also available in HTML form.
     </tr>
     <tr>
     <td>2009-07-30 15:48</td><td>2</td><td>0</td><td>1</td><td><font size="+2"><strong>1</strong></font></td><td>0</td>
-    <td>3</td><td>     20.43</td><td>     20.35</td>
+    <td>3</td><td>     20.00</td><td>     20.00</td>
     </tr>
     </table>
     <table border="1">
@@ -381,11 +381,11 @@ Again, this report is also available in HTML form.
     </tr>
     <tr style="background: lightgrey">
     <td>2009-07-30 15:49</td><td>0</td><td>0</td><td>0</td><td><font size="+2"><strong>0</strong></font></td><td>0</td>
-    <td>4</td><td>     31.81</td><td>     15.85</td>
+    <td>4</td><td>     31.69</td><td>     15.67</td>
     </tr>
     <tr>
     <td>2009-07-30 15:50</td><td>2</td><td>0</td><td>0</td><td><font size="+2"><strong>2</strong></font></td><td>0</td>
-    <td>2</td><td>      0.34</td><td>      0.17</td>
+    <td>2</td><td>      0.34</td><td>      0.10</td>
     </tr>
     </table>
     <table border="1">
@@ -411,7 +411,7 @@ Again, this report is also available in HTML form.
     </tr>
     <tr style="background: lightgrey">
     <td>2009-07-30 15:51</td><td>3</td><td>0</td><td>1</td><td><font size="+2"><strong>1</strong></font></td><td>1</td>
-    <td>5</td><td>     12.31</td><td>     12.25</td>
+    <td>5</td><td>     12.08</td><td>     12.07</td>
     </tr>
     </table>
     <table border="1">
@@ -434,7 +434,7 @@ Again, this report is also available in HTML form.
     </tr>
     <tr>
     <td>2009-07-30 15:52</td><td>3</td><td>0</td><td>1</td><td><font size="+2"><strong>2</strong></font></td><td>0</td>
-    <td>8</td><td>     20.65</td><td>      2.52</td>
+    <td>8</td><td>     20.45</td><td>      2.29</td>
     </tr>
     </table>
     <table border="1">
@@ -460,7 +460,7 @@ Again, this report is also available in HTML form.
     </tr>
     <tr style="background: lightgrey">
     <td>2009-07-30 15:53</td><td>3</td><td>0</td><td>2</td><td><font size="+2"><strong>1</strong></font></td><td>0</td>
-    <td>11</td><td>     14.53</td><td>      6.53</td>
+    <td>11</td><td>     14.39</td><td>      6.39</td>
     </tr>
     </table>
     <table border="1">
@@ -516,12 +516,12 @@ Again, this report is also available in HTML form.
     <td>/stars/alpha-centauri.html</td>
     </tr>
     <tr>
-    <td><a name="u96">60.7</a></td><td>2</td><td>0.337</td><td>30.340</td><td>30.340</td><td>60.343</td><td>0</td>
-    <td>/space-travel/plans/supplies.txt</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u106">60.3</a></td><td>2</td><td>0.133</td><td>30.134</td><td>30.134</td><td>60.134</td><td>0</td>
     <td>/favicon.png</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u96">60.0</a></td><td>2</td><td>0.003</td><td>30.003</td><td>30.003</td><td>60.003</td><td>0</td>
+    <td>/space-travel/plans/supplies.txt</td>
     </tr>
     <tr>
     <td><a name="u110">9.7</a></td><td>1</td><td>9.694</td><td>9.694</td><td>9.694</td><td>9.694</td><td>0</td>
@@ -536,96 +536,96 @@ Again, this report is also available in HTML form.
     <td>/planets/jupiter.html</td>
     </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u118">1.0</a></td><td>3</td><td>0.309</td><td>0.353</td><td>0.346</td><td>0.378</td><td>0</td>
-    <td>/space-travel/plans/signals.html</td>
-    </tr>
-    <tr>
     <td><a name="u122">0.9</a></td><td>1</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0.880</td><td>0</td>
     <td>/stories/aliens-posing-as-humans.html</td>
     </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u98">0.8</a></td><td>2</td><td>0.352</td><td>0.388</td><td>0.388</td><td>0.423</td><td>0</td>
-    <td>/space-travel/plans/launchpad.html</td>
-    </tr>
     <tr>
-    <td><a name="u124">0.7</a></td><td>1</td><td>0.364</td><td>0.364</td><td>0.364</td><td>0.364</td><td>1</td>
-    <td>/space-travel/plans/orbit.html</td>
-    </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u100">0.7</a></td><td>2</td><td>0.339</td><td>0.361</td><td>0.361</td><td>0.384</td><td>0</td>
-    <td>/space-travel/plans/space-logs.txt</td>
-    </tr>
-    <tr>
-    <td><a name="u97">0.7</a></td><td>2</td><td>0.347</td><td>0.349</td><td>0.349</td><td>0.351</td><td>0</td>
-    <td>/space-travel/plans/moon-base.jpg</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u95">0.6</a></td><td>1</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0.638</td><td>0</td>
     <td>/columns/t-jansen</td>
-    </tr>
-    <tr>
-    <td><a name="u107">0.5</a></td><td>3</td><td>0.153</td><td>0.161</td><td>0.164</td><td>0.177</td><td>0</td>
-    <td>/space-travelers/famous/kirk.jpg</td>
-    </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u108">0.4</a></td><td>1</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0.397</td><td>0</td>
-    <td>/space-travel/plans/moon-buggy.jpg</td>
-    </tr>
-    <tr>
-    <td><a name="u111">0.4</a></td><td>1</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0.379</td><td>0</td>
-    <td>/space-travel/plans/space-diary.txt</td>
     </tr>
     <tr style="background: lightgrey;">
     <td><a name="u103">0.4</a></td><td>2</td><td>0.184</td><td>0.187</td><td>0.187</td><td>0.190</td><td>0</td>
     <td>/faqs/how-to-recognize-lazer-fire.html</td>
     </tr>
     <tr>
-    <td><a name="u120">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
-    <td>/js/photo.js</td>
-    </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u125">0.4</a></td><td>1</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0.354</td><td>0</td>
-    <td>/space-travel/plans/visor.jpg</td>
-    </tr>
-    <tr>
-    <td><a name="u114">0.4</a></td><td>1</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0.353</td><td>0</td>
-    <td>/space-travel/plans/lunar-cycles.html</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u116">0.4</a></td><td>1</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0.351</td><td>0</td>
     <td>/faqs/how-to-charge-lazers.html</td>
     </tr>
-    <tr>
-    <td><a name="u102">0.3</a></td><td>1</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0.333</td><td>0</td>
-    <td>/space-travel/plans/cryostasis.txt</td>
-    </tr>
     <tr style="background: lightgrey;">
-    <td><a name="u109">0.3</a></td><td>1</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0.321</td><td>0</td>
-    <td>/space-travel/plans/space-suit.jpg</td>
-    </tr>
-    <tr>
     <td><a name="u112">0.3</a></td><td>1</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0.320</td><td>0</td>
     <td>/space-travel/ships/tardis.html</td>
     </tr>
-    <tr style="background: lightgrey;">
+    <tr>
     <td><a name="u101">0.3</a></td><td>1</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0.253</td><td>0</td>
     <td>/approve-photo</td>
     </tr>
-    <tr>
+    <tr style="background: lightgrey;">
     <td><a name="u119">0.2</a></td><td>1</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0.182</td><td>0</td>
     <td>/ufo-sightings/report</td>
     </tr>
-    <tr style="background: lightgrey;">
-    <td><a name="u121">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
-    <td>/space-travelers/famous/spock.jpg</td>
-    </tr>
     <tr>
-    <td><a name="u105">0.2</a></td><td>1</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0.157</td><td>0</td>
-    <td>/login</td>
-    </tr>
-    <tr style="background: lightgrey;">
     <td><a name="u123">0.1</a></td><td>1</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0.138</td><td>0</td>
     <td>/space-travel/ships/soyuz.html</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u107">0.0</a></td><td>3</td><td>0.015</td><td>0.016</td><td>0.016</td><td>0.018</td><td>0</td>
+    <td>/space-travelers/famous/kirk.jpg</td>
+    </tr>
+    <tr>
+    <td><a name="u121">0.0</a></td><td>1</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0</td>
+    <td>/space-travelers/famous/spock.jpg</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u105">0.0</a></td><td>1</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0.016</td><td>0</td>
+    <td>/login</td>
+    </tr>
+    <tr>
+    <td><a name="u118">0.0</a></td><td>3</td><td>0.003</td><td>0.004</td><td>0.003</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/signals.html</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u98">0.0</a></td><td>2</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/launchpad.html</td>
+    </tr>
+    <tr>
+    <td><a name="u124">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>1</td>
+    <td>/space-travel/plans/orbit.html</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u100">0.0</a></td><td>2</td><td>0.003</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/space-logs.txt</td>
+    </tr>
+    <tr>
+    <td><a name="u97">0.0</a></td><td>2</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/moon-base.jpg</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u108">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/moon-buggy.jpg</td>
+    </tr>
+    <tr>
+    <td><a name="u111">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/space-diary.txt</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u120">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/js/photo.js</td>
+    </tr>
+    <tr>
+    <td><a name="u125">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/visor.jpg</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u114">0.0</a></td><td>1</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0.004</td><td>0</td>
+    <td>/space-travel/plans/lunar-cycles.html</td>
+    </tr>
+    <tr>
+    <td><a name="u102">0.0</a></td><td>1</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0</td>
+    <td>/space-travel/plans/cryostasis.txt</td>
+    </tr>
+    <tr style="background: lightgrey;">
+    <td><a name="u109">0.0</a></td><td>1</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0.003</td><td>0</td>
+    <td>/space-travel/plans/space-suit.jpg</td>
     </tr>
     <tr>
     <td><a name="u104">&nbsp;</a></td><td>0</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>1</td>
@@ -641,12 +641,12 @@ Report by given time interval.
     <BLANKLINE>
               minute   req input  wait   app output
     ================ ===== ===== ===== ===== ======
-    2009-07-30 15:48     2 I=  0 W=  1 A=  1 O=   0 N=   2       0.43       0.35
-    2009-07-30 15:49     0 I=  0 W=  0 A=  0 O=   0 N=   4      31.81      15.85
-    2009-07-30 15:50     2 I=  0 W=  0 A=  2 O=   0 N=   2       0.34       0.17
-    2009-07-30 15:51     3 I=  0 W=  1 A=  1 O=   1 N=   5      12.31      12.25
+    2009-07-30 15:48     2 I=  0 W=  1 A=  1 O=   0 N=   2       0.00       0.00
+    2009-07-30 15:49     0 I=  0 W=  0 A=  0 O=   0 N=   4      31.69      15.67
+    2009-07-30 15:50     2 I=  0 W=  0 A=  2 O=   0 N=   2       0.34       0.10
+    2009-07-30 15:51     3 I=  0 W=  1 A=  1 O=   1 N=   5      12.08      12.07
     Left over:
-    140.94385 /submit-photo
+    140.094385 /submit-photo
     <BLANKLINE>
     <BLANKLINE>
     URL statistics:
@@ -656,20 +656,20 @@ Report by given time interval.
          60.1     1  60.13  60.13  60.13  60.13     0 /favicon.png
           9.7     1   9.69   9.69   9.69   9.69     0 /planets/saturn.html
           8.3     1   8.30   8.30   8.30   8.30     0 /moons/io.html
-          0.8     2   0.35   0.39   0.39   0.42     0 /space-travel/plans/launchpad.html
-          0.7     2   0.35   0.35   0.35   0.35     0 /space-travel/plans/moon-base.jpg
-          0.4     1   0.40   0.40   0.40   0.40     0 /space-travel/plans/moon-buggy.jpg
-          0.4     1   0.38   0.38   0.38   0.38     0 /space-travel/plans/space-logs.txt
-          0.4     1   0.38   0.38   0.38   0.38     0 /space-travel/plans/space-diary.txt
           0.4     2   0.18   0.19   0.19   0.19     0 /faqs/how-to-recognize-lazer-fire.html
-          0.4     1   0.35   0.35   0.35   0.35     0 /space-travel/plans/lunar-cycles.html
-          0.3     1   0.34   0.34   0.34   0.34     0 /space-travel/plans/supplies.txt
-          0.3     1   0.33   0.33   0.33   0.33     0 /space-travel/plans/cryostasis.txt
-          0.3     1   0.32   0.32   0.32   0.32     0 /space-travel/plans/space-suit.jpg
           0.3     1   0.32   0.32   0.32   0.32     0 /space-travel/ships/tardis.html
           0.3     1   0.25   0.25   0.25   0.25     0 /approve-photo
-          0.2     1   0.18   0.18   0.18   0.18     0 /space-travelers/famous/kirk.jpg
-          0.2     1   0.16   0.16   0.16   0.16     0 /login
+          0.0     1   0.02   0.02   0.02   0.02     0 /space-travelers/famous/kirk.jpg
+          0.0     1   0.02   0.02   0.02   0.02     0 /login
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/launchpad.html
+          0.0     2   0.00   0.00   0.00   0.00     0 /space-travel/plans/moon-base.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/moon-buggy.jpg
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-logs.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-diary.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/lunar-cycles.html
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/supplies.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/cryostasis.txt
+          0.0     1   0.00   0.00   0.00   0.00     0 /space-travel/plans/space-suit.jpg
                   0                                 1 /submit-photo
                   0                                 1 /stars/alpha-centauri.html
                   0                                 1 /faqs/how-to-charge-lazers.html

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,19 @@
 [tox]
 envlist =
-    py26,py27,pypy
+    py27,pypy,py34,py35,py36,py37,pypy3
 
 [testenv]
+extras = test
 deps =
-    zope.testing < 4.0.0
     zope.testrunner
 commands =
     zope-testrunner --test-path=src {posargs:-pvc}
+
+[testenv:coverage]
+usedevelop = true
+deps =
+    {[testenv]deps}
+    coverage
+commands =
+    coverage run -m zope.testrunner --test-path=src {posargs:-pvc}
+    coverage report -m


### PR DESCRIPTION
Had to switch to manuel because zope.testing.doctest is gone and
stdlib's doctest doesn't support INTERPRET_FOOTNOTES.

Had to reduce the precision of floating point numbers in HTML reports
because Python 3 formats floats slightly differently.

Could not resist fixing a bug in find_restarts(), which is not covered
by tests: the parse_dt() it was trying to call did was replaced by
parse_datetime() in commit 9ba3d7f6c987164fa9a0580ba986aea8bb140e0b

~~Did resist fixing a logic bug in seconds_difference(), but added an XXX
comment.~~

Fixed the bug in second_difference(), as long as we're replacing the huge blobs of text in the doctest anyway.